### PR TITLE
changed default admin rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 IBM Installation Manager Cookbook CHANGELOG
 ========================
 
+v1.2.0
+--------------------
+- change default access_rights from nonAdmin to admin
+
 v1.1.1
 --------------------
 - update readme with ibm_fixpack

--- a/libraries/ibm_package.rb
+++ b/libraries/ibm_package.rb
@@ -35,7 +35,7 @@ module InstallMgrCookbook
     property :preferences, [Hash, nil], default: nil
     property :install_fixes, String, default: 'none', regex: /^(none|recommended|all)$/
     property :additional_options, String, default: ''
-    property :access_rights, String, default: 'nonAdmin', regex: /^(nonAdmin|admin|group)$/
+    property :access_rights, String, default: 'admin', regex: /^(nonAdmin|admin|group)$/
     property :log_dir, String, default: '/var/IBM/InstallationManager/logs'
     property :secure_storage_file, [String, nil], default: nil
     property :master_pw_file, [String, nil], default: nil
@@ -50,7 +50,6 @@ module InstallMgrCookbook
 
     action :install do
       unless package_installed?(package, imcl_dir)
-
         user service_user do
           comment 'ibm installation mgr service account'
           home "/home/#{service_user}"
@@ -102,7 +101,6 @@ module InstallMgrCookbook
         options << " -preferences #{preferences_str}" if preferences
 
         imcl_wrapper(imcl_dir, "./imcl install '#{package}' -showProgress", options)
-
       end
     end
 

--- a/libraries/install_mgr.rb
+++ b/libraries/install_mgr.rb
@@ -36,7 +36,7 @@ module InstallMgrCookbook
     property :data_location, String, default: '/var/IBM/InstallationManager'
     property :service_user, String, default: 'ibm-im'
     property :service_group, String, default: 'ibm-im'
-    property :access_rights, String, default: 'nonAdmin', regex: /^(nonAdmin|admin|group)$/
+    property :access_rights, String, default: 'admin', regex: /^(nonAdmin|admin|group)$/
     property :preferences, String, default: 'offering.service.repositories.areUsed=false'
 
     provides :install_mgr if defined?(provides)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'devops@sainsburys.co.uk'
 license 'Apache 2.0'
 description 'Installs/Configures IBM Installation Manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.1'
+version '1.2.0'


### PR DESCRIPTION
default admin access should be set to 'admin'.  This is just for the context under which installation manager installs packages, not related to service accounts running processes.