### PR TITLE
Chef13 deprecations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,21 @@ LineLength:
 ##  don't need class documentation header for custom resources.
 Documentation:
   Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': []
+    '%I': []
+    '%w': []
+    '%W': []
+    '%i': '[]'
+    '%I': '[]'
+    '%w': '[]'
+    '%W': '[]'
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,38 @@
 rvm: 2.2
-
 sudo: required
-
 addons:
   apt:
     sources:
-      - chef-stable-precise
+    - chef-stable-precise
     packages:
-      - chefdk
-
+    - chefdk
 install: echo "skip bundle install"
-
 services: docker
-
 env:
+  global:
+  - secure: FpIjnMHGr5UKmoWXt9xooKmIc0t+XOhNKllS1ZNLsxa0IlCsjhsJGf2CMVTSf7f6Do5jgD1aJDb2+7QbLEpqSyqTAQ/J+8KQgkSNn+zuJ/PvSp6hkfzP2nBgKfuBEea9CnS2GzZZ+BfPKht3BwcQcy6VrAmcq6W7zNVbfotRbBp6fD/GB3EQ4uyb+BXvSTTB1ol6i9Qb2Ax6cj1bOHJNE6GGrCiQlQV0C9tedKEgp7GxTvOJa/O6syVNpnmL9eOYcJdhy0qiJfmnuaAIWVLxdexdITgBBexyVl4TnZu6w6AHjC8WHxUCPXF3vx0lEowB+O+tOZ4dkNFgJUSDWbAfI+/XF5wu/KgAd/hrtNf0hujOGIk8iuv8OsVKt+guy6/zkcuXd/cmmBK2+unSZHeG/M9x/Nf8LE0Gs8v+kU4hg3sSpWcL2+vbWuUQlyJ2mH7S0Io5GeoAxfpFHUNwQtLiQG3w8c7F4Z+jQUXxtuzkAqY++NwUU+0ZuA+ZDk1X8aiBYqSCoksyYcKk3LQ6FtjukKFbkOJ+xLTPMoUkW9ytQN4lGV/FVC6LIjRLffy/F107thNWI6cc0l3u5Q80jw27qpzWIVzQaD0z9UKyc5hfJe2IgSOn16V9eEFWsedKDssyq4aY3JYjeGJNYWBcyfKLwwuR7LBjVZNPRWMmAHIMTeY=
+  - secure: qXlYDTj0hovjabiGrL9cpO1XmR+38WYROw13ZEfJ4CGNYOnTC4qICrV1xGO7MPLBtv1rl9eeR3p6JhLaywN+zWVmstFue1kdMYGuyfEeVAhpFwrT749r1rijSHK+utbg00vv6BE+K+7nNVTVn+i8YLR9l0d2oy5chEOmv/DEhpk7v58aCqEhuqc/D91XP5jxBBpc0EFVo/xZMTRuPjfzk38xxKb6fihHC1CviODXZLBRLi/cpCR4mxgIj+X3ep9pHwWsW0y7cHxsYhvpYEMiuYNXRwmmc7p/K/RFeJhPMXnQlKlIUO9Qt5ypR0oMSS2vsY0Y0AvwzHqjAc0UF/rQ0WIEatefv7OdN+9SL/QWC+e9uu6LKD40eZrNYU7RzP7pAmFwXObZ7lm7shjmSDTvoA4WvIuOzV3OURJW5Vh8zNR6qsoTMfx+0VP1KdlN3oVr6M/PYCRSfly1LHucsyAzEUMLZaB75CRvMvyO2mU44Zx+izrkiOZxrV4oYBUT0blEiRq12B9kj7kAmzVoqBambErzpuOaHeJCx73UKScxNg51ikdA5+tU+6zhib7z16XV07SGt/GHy9x1zSXzxHdez4V/3O9GzWzi6k2v01jmPTt/xMcv0Uwlh2tPJvkkT4Rnssmus44q9dj5Z0UCXKLA7DZ12y244gz24QgUwn1GDkA=
   matrix:
   - INSTANCE=install-im-centos-6
   - INSTANCE=install-im-centos-7
-  #- INSTANCE=install-im-ubuntu-1204
-  #- INSTANCE=install-im-ubuntu-1404
   - INSTANCE=install-passport-centos-6
   - INSTANCE=install-passport-centos-7
-  #- INSTANCE=install-passport-ubuntu-1204
-  #- INSTANCE=install-passport-ubuntu-1404
   fast_finish: true
-
 before_script:
-  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-  - /opt/chefdk/embedded/bin/chef gem install kitchen-dokken
-
+- sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables
+  -N DOCKER )
+- eval "$(/opt/chefdk/bin/chef shell-init bash)"
+- "/opt/chefdk/embedded/bin/chef gem install kitchen-dokken"
 script:
-  - bundle install
-  - /opt/chefdk/embedded/bin/chef --version
-  - chefstyle --version
-  - chefstyle
-  - foodcritic --version
-  - foodcritic . --exclude spec
-  - chef exec rspec
-  - KITCHEN_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
-
+- bundle install
+- "/opt/chefdk/embedded/bin/chef --version"
+- chefstyle --version
+- chefstyle
+- foodcritic --version
+- foodcritic . --exclude spec
+- chef exec rspec
+- KITCHEN_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
 after_script:
-  - docker images
-  - docker ps -a
-  - cat .kitchen/logs/kitchen.log
+- docker images
+- docker ps -a
+- cat .kitchen/logs/kitchen.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ before_script:
 script:
   - bundle install
   - /opt/chefdk/embedded/bin/chef --version
-  - rubocop --version
-  - rubocop
+  - chefstyle --version
+  - chefstyle
   - foodcritic --version
   - foodcritic . --exclude spec
-  - bundle exec rspec
+  - chef exec rspec
   - KITCHEN_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
 
 after_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,24 @@
-IBM Installation Manager Cookbook CHANGELOG
-========================
+# IBM Installation Manager Cookbook CHANGELOG
 
 v1.3.0
 --------------------
+
 - fix Chef 13 deprecation messages
 
 v1.2.0
 --------------------
+
 - change default access_rights from nonAdmin to admin
 
 v1.1.1
 --------------------
-- update readme with ibm_fixpack
-- remove java depenency as it's not needed
+
+- update README with ibm_fixpack
+- remove java dependency as it's not needed
 
 v1.1.0
 --------------------
+
 - add sensitive_exec override for debugging.
 - fix property warnings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 IBM Installation Manager Cookbook CHANGELOG
 ========================
 
+v1.3.0
+--------------------
+- fix Chef 13 deprecation messages
+
 v1.2.0
 --------------------
 - change default access_rights from nonAdmin to admin

--- a/README.md
+++ b/README.md
@@ -10,18 +10,20 @@ This cookbook currently uses the Installation Manager Installer method rather th
 Group install mode has not been tested. Only admin and nonAdmin have.
 
 ## Requirements
+
 * Chef 12.5 or higher
 * Installation Media for Installation manager and any other packages.
 This can be sourced from an online repository like IBM PassportAdvantage, or from your own download link.  Supports tar, tar.gz and zip.
-* Installation Kits may need to be packaged into a single folder.  For example the Websphere installation kit comes in 3 folders disk1, disk2 and disk3.  Make sure all disks are in the same folder like so:
+* Installation Kits may need to be packaged into a single folder.  For example the WebSphere installation kit comes in 3 folders disk1, disk2 and disk3.  Make sure all disks are in the same folder like so:
 
-  - WAS/
-  - WAS/disk1/
-  - WAS/disk2/
-  - WAS/disk3/
-  - WAS/repository.config
+  * WAS/
+  * WAS/disk1/
+  * WAS/disk2/
+  * WAS/disk3/
+  * WAS/repository.config
 
 ## Platforms
+
 * Centos 6
 * Red Hat Enterprise 6
 * Centos 7
@@ -31,9 +33,9 @@ This can be sourced from an online repository like IBM PassportAdvantage, or fro
 
 See the test cookbook in test/fixtures/cookbooks/ibm-im-test for examples.
 
-##### Install Installation Manager
-```ruby
+### Install Installation Manager
 
+```ruby
 install_mgr 'ibm-im install' do
   install_package 'https://myrepository/agent.installer.linux.gtk.x86_64_1.8.4000.20151125_0201.zip'
   install_package_sha256 '28f5279abc28695c0b99ae0c3fdee26bfec131186f2ca7e41d1317e303adb12e'
@@ -59,10 +61,9 @@ ibm_package 'IHS install' do
   master_pw_file '/root/MyMasterPassFile'
   action :install
 end
-
 ```
 
-##### Install Websphere with Installation Manager
+### Install WebSphere with Installation Manager
 
 ```ruby
 # installation manager must be installed before calling this resource
@@ -77,12 +78,12 @@ end
 
 ### Resources
 
-
 ### install_mgr
 
 Installs IBM Installation Manager
 
 ##### Example
+
 ```ruby
 install_mgr 'ibm-im install' do
   install_package 'https://some-repository/agent.installer.linux.gtk.x86_64_1.8.4000.20151125_0201.zip'
@@ -96,31 +97,31 @@ end
 
 ##### Parameters
 
-- `:install_package`, Url or local path to a compressed file. Must be .tar, .tar.gz or .zip. String, required: true, default: nil
-- `:install_package_sha256`, Hash of install package. String, default: nil
-- `:download_temp_dir`, Scratch folder to download to. String, default: Chef::Config['file_cache_path']
-- `:extract_dir`, String, default: ""#{download_temp_dir}/ibm-installmgr"
-- `:install_dir`, String, default: "#{ibm_root_dir}/InstallationManager/eclipse"
-- `:package_name`, String, default: 'com.ibm.cic.agent'
-- `:repositories`, [String, Array], default: [extract_dir]
-- `:ibm_root_dir`, String, default: '/opt/IBM'
-- `:data_location`, This is where Installation Manager stores data about it's installed packages. String, default: '/var/ibm/InstallationManager'
-- `:service_user`, String, default: 'ibm-im'
-- `:service_group`, String, default: 'ibm-im'
-- `:access_rights`, String, default: 'nonAdmin', Can only be nonAdmin, admin or group.  Group is not tested.
-- `:preferences`, A hash of preferences that are often contained within a response file. Hash, default: nil
-- `:properties`, A hash of properties that are often contained within a response file. Can be used in place of response file. [Hash], default: nil
+* `:install_package`, Url or local path to a compressed file. Must be .tar, .tar.gz or .zip. String, required: true, default: nil
+* `:install_package_sha256`, Hash of install package. String, default: nil
+* `:download_temp_dir`, Scratch folder to download to. String, default: Chef::Config['file_cache_path']
+* `:extract_dir`, String, default: ""#{download_temp_dir}/ibm-installmgr"
+* `:install_dir`, String, default: "#{ibm_root_dir}/InstallationManager/eclipse"
+* `:package_name`, String, default: 'com.ibm.cic.agent'
+* `:repositories`, [String, Array], default: [extract_dir]
+* `:ibm_root_dir`, String, default: '/opt/IBM'
+* `:data_location`, This is where Installation Manager stores data about it's installed packages. String, default: '/var/ibm/InstallationManager'
+* `:service_user`, String, default: 'ibm-im'
+* `:service_group`, String, default: 'ibm-im'
+* `:access_rights`, String, default: 'nonAdmin', Can only be nonAdmin, admin or group.  Group is not tested.
+* `:preferences`, A hash of preferences that are often contained within a response file. Hash, default: nil
+* `:properties`, A hash of properties that are often contained within a response file. Can be used in place of response file. [Hash], default: nil
 
 ##### Actions
 
-- `:install` - Installs Installation Manager. Does not start it as this requires gui.
-
+* `:install` - Installs Installation Manager. Does not start it as this requires gui.
 
 ### ibm_package
 
 Installs an IBM application using Installation Manager
 
 ##### Example
+
 ```ruby
 # ... omitted ibm_secure_storage_file resource.
 
@@ -168,37 +169,37 @@ ibm_package 'IBM Diretcory Server' do
   sensitive_exec false
   action :install
 end
-
 ```
 
 ##### Parameters
 
-- `:package`, The package application id to install. Eg 'com.ibm.websphere.ND.v85_8.5.5000.20130514_1044', String required: true, default: nil
-- `install_dir`, Where to install the package. String, required: true, default: nil
-- `imcl_dir`, Path to the imcl utility binary You shouldn't need to change this. String, default: '/opt/IBM/InstallationManager/eclipse/tools'
-- `repositories`, Array of local dirs or urls to repositories.  Installation Kits may need to be packaged into a single folder, see the Requirements section above. [String, Array], required: true, default: nil
-- `service_user`, String, default: 'ibm'
-- `service_group`, String, default: 'ibm'
-- `properties`, Hash, A hash of properties that are usually found in response files.
-- `preferences`, Hash, A hash of preferences that are usually found in response files.
-- `additional_options`, a string of additional options to append if needed. String, default: ''
-- `access_rights`, String, default: 'nonAdmin', regex: /^(nonAdmin|admin|group)$/
-- `log_dir`, String, default: '/var/ibm/InstallationManager/logs'
-- `:passport_advantage`, When set to true adds passportAdvantafe repo url to repositories. default: false
-- `:secure_storage_file`, path to secure storage file to use for repo credentials. String, default: nil
-- `:master_pw_file`, path to file containing password to access encrypted secure_storage_file. String, default: nil
-- `:sensitive_exec`, Default: true, Only change this in exceptional debugging circumstances. When set to false you can see the imcl command being executed in the chef logs, which could contain a password.
+* `:package`, The package application id to install. Eg 'com.ibm.websphere.ND.v85_8.5.5000.20130514_1044', String required: true, default: nil
+* `install_dir`, Where to install the package. String, required: true, default: nil
+* `imcl_dir`, Path to the imcl utility binary You shouldn't need to change this. String, default: '/opt/IBM/InstallationManager/eclipse/tools'
+* `repositories`, Array of local dirs or urls to repositories.  Installation Kits may need to be packaged into a single folder, see the Requirements section above. [String, Array], required: true, default: nil
+* `service_user`, String, default: 'ibm'
+* `service_group`, String, default: 'ibm'
+* `properties`, Hash, A hash of properties that are usually found in response files.
+* `preferences`, Hash, A hash of preferences that are usually found in response files.
+* `additional_options`, a string of additional options to append if needed. String, default: ''
+* `access_rights`, String, default: 'nonAdmin', regex: /^(nonAdmin|admin|group)$/
+* `log_dir`, String, default: '/var/ibm/InstallationManager/logs'
+* `:passport_advantage`, When set to true adds passportAdvantafe repo url to repositories. default: false
+* `:secure_storage_file`, path to secure storage file to use for repo credentials. String, default: nil
+* `:master_pw_file`, path to file containing password to access encrypted secure_storage_file. String, default: nil
+* `:sensitive_exec`, Default: true, Only change this in exceptional debugging circumstances. When set to false you can see the imcl command being executed in the chef logs, which could contain a password.
+
 ##### Actions
 
-- `:install` - Installs the package. Does not start, setup a service at this stage.
+* `:install` - Installs the package. Does not start, setup a service at this stage.
 
 ### ibm_fixpack
 
 Similar to ibm_package but specifically installs an IBM fixpack. All parameters are exactly the same as ibm_package.
 
 ##### Example
-```ruby
 
+```ruby
 # ... omitted required ibm_secure_storage_file resource.
 
 ibm_fixpack 'WAS ND Fixpack' do
@@ -209,7 +210,6 @@ ibm_fixpack 'WAS ND Fixpack' do
   secure_storage_file '/root/MySecureStorageFile'
   action :install
 end
-
 ```
 
 ##### Parameters
@@ -218,14 +218,14 @@ Exactly the same as parameters for ibm_package
 
 ##### Actions
 
-- `:install`
-
+* `:install`
 
 ### ibm_response_file
 
 A simple wrapper around the template resource to create a response file for the ibm_package_response resource. You can use the template resource directly if you like.
 
 ##### Example
+
 ```ruby
 ibm_response_file '/opt/IBM/response_files/my_was_response.xml' do
   cookbook 'ibm-im-test'
@@ -234,22 +234,21 @@ ibm_response_file '/opt/IBM/response_files/my_was_response.xml' do
     :key1 => 'val1'
   })
 end
-
 ```
 
 ##### Parameters
-- `:package`, The package application id to install. Eg 'com.ibm.websphere.ND.v85_8.5.5000.20130514_1044', String required: true, default: nil,  name_property: true
-- `response_file`, Path to create the response file. String
-- `group`, File group. String, default: 'ibm-im'
-- `owner`, File owner. String, default: 'ibm-im'
-- `template_source`, String, default: nil
-- `cookbook`, String, default: nil
-- `variables`, [Hash], default: nil
+
+* `:package`, The package application id to install. Eg 'com.ibm.websphere.ND.v85_8.5.5000.20130514_1044', String required: true, default: nil,  name_property: true
+* `response_file`, Path to create the response file. String
+* `group`, File group. String, default: 'ibm-im'
+* `owner`, File owner. String, default: 'ibm-im'
+* `template_source`, String, default: nil
+* `cookbook`, String, default: nil
+* `variables`, [Hash], default: nil
 
 ##### Actions
 
-- `:create`
-
+* `:create`
 
 ### ibm_package_response
 
@@ -259,33 +258,33 @@ Installs an IBM package using a response file.
 Please note you may need to create and required users and directories mentioned in the response file first.  You do not need to accept the license or set the accessRights in the response file, this is handled with the command.
 
 ##### Example
+
 ```ruby
 ibm_package_response 'com.ibm.websphere.ND.v85' do
   response_file '/opt/IBM/response_files/my_was_response.xml'
   action :install
 end
-
 ```
 
 ##### Parameters
 
-- `response_file`, String, name_property: true, required: true
-- `imcl_dir`, String, default: '/opt/IBM/InstallationManager/eclipse/tools'
-- `log_dir`, String, default: '/var/ibm/InstallationManager/logs'
-- `pkg_group`, Only used to for log_dir. String, default: 'ibm-im'
-- `pkg_owner`, Only used to for log_dir String, default: 'ibm-im'
-- `access_rights`, String, default: 'nonAdmin', regex: /^(nonAdmin|admin|group)$/
+* `response_file`, String, name_property: true, required: true
+* `imcl_dir`, String, default: '/opt/IBM/InstallationManager/eclipse/tools'
+* `log_dir`, String, default: '/var/ibm/InstallationManager/logs'
+* `pkg_group`, Only used to for log_dir. String, default: 'ibm-im'
+* `pkg_owner`, Only used to for log_dir String, default: 'ibm-im'
+* `access_rights`, String, default: 'nonAdmin', regex: /^(nonAdmin|admin|group)$/
 
 ##### Actions
 
-- `:install`
-
+* `:install`
 
 ### ibm_secure_storage_file
 
 Creates an encrypted Eclipse Storage file to store password credentials to repositories such as IBM passport Advantage.
 
 ##### Example
+
 ```ruby
 ibm_secure_storage_file '/root/MySecureStorageFile' do
   master_pw_file '/root/MyMasterPassFile'
@@ -298,24 +297,24 @@ end
 
 ##### Parameters
 
-- `secure_file`, String, name_property: true
-- `master_pw_file`, Contains the password to access the secure_file. String
-- `master_pw`, password to put in master_pw_file. String, default: nil
-- `url`, String, default: 'http://www.ibm.com/software/repositorymanager/entitled/repository.xml'
-- `passport_advantage`, Set to true when credentials are to access passportAdvantage. The url will be ignored if set. [TrueClass, FalseClass], default: false
-- `username`, String, default: nil
-- `password`, For encrypting the secure file. String, default: nil
-- `imutilsc_dir`, Path to imutilsc binary. You shouldn't need to change this from the default. String, default: '/opt/IBM/InstallationManager/eclipse/tools'
+* `secure_file`, String, name_property: true
+* `master_pw_file`, Contains the password to access the secure_file. String
+* `master_pw`, password to put in master_pw_file. String, default: nil
+* `url`, String, default: 'http://www.ibm.com/software/repositorymanager/entitled/repository.xml'
+* `passport_advantage`, Set to true when credentials are to access passportAdvantage. The url will be ignored if set. [TrueClass, FalseClass], default: false
+* `username`, String, default: nil
+* `password`, For encrypting the secure file. String, default: nil
+* `imutilsc_dir`, Path to imutilsc binary. You shouldn't need to change this from the default. String, default: '/opt/IBM/InstallationManager/eclipse/tools'
+
 ##### Actions
 
-- `:create`
-
+* `:create`
 
 ## License and Author
 
-* Author: Lachlan Munro, Chris Bell
+* Authors: Lachlan Munro, Chris Bell
 
-Copyright: 2015, J Sainsburys
+Copyright: 2018, J Sainsburys
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -312,9 +312,9 @@ end
 
 ## License and Author
 
-* Authors: Lachlan Munro, Chris Bell
+* Authors: Lachlan Munro, Chris Bell, Chris Minton
 
-Copyright: 2018, J Sainsburys
+Copyright: 2015-2018, J Sainsburys
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ namespace :style do
     FoodCritic::Rake::LintTask.new(:chef) do |t|
       t.options = {
         fail_tags: ['any'],
-        exclude_paths: ['spec']
+        exclude_paths: ['spec'],
       }
     end
   rescue LoadError

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,50 +1,57 @@
 
-Cookbook TESTING doc
-====================
+# Cookbook TESTING doc
 
-Testing Prerequisites
----------------------
+## Testing Prerequisites
+
 This cookbook tries to emulate the testing standards in https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
 
-Style Testing
--------------
+## Style Testing
+
 Ruby style tests can be performed by Rubocop by issuing either
-```
+
+```shell
 bundle exec rubocop
 ```
+
 or
-```
+
+```shell
 rake style:ruby
 ```
 
 Chef style/correctness tests can be performed with Foodcritic by issuing either
-```
+
+```shell
 bundle exec foodcritic
 ```
+
 or
-```
+
+```shell
 rake style:chef
 ```
 
-Spec Testing
--------------
-```
+## Spec Testing
+
+```shell
 rake unit
 ```
 
-Integration Testing
--------------------
+## Integration Testing
 
-You can run the install_im suite without any media, as it's available in S3.
+You can run the `install_im` suite without any media, as it's available in S3.
 
-In order to run install_passport you need to set a Passport Advantage login in environment variables:
+In order to run `install_passport` you need to set a Passport Advantage login in environment variables:
+
+```shell
 export PASSPORTADV_USER=myuser@myemail.com
 export PASSPORTADV_PW=mypassword
+```
 
 Unfortunately a lot of the packages in the Passport Advantage repo are incomplete, so in order to run the kitchen suites with Vagrant you will need to have the WAS 8.5 installation kit available at /opt/ibm-media/WASND in the vagrant vm.
-You can do this in your kitchen.local.yml with something like
-```
----
+You can do this in your `.kitchen.local.yml` with something like
+
+```yaml
 ---
 suites:
   - name: install_im
@@ -65,15 +72,16 @@ suites:
         - ["~/sainsburys/identity/media", "/opt/ibm-media"]
     run_list:
     - recipe[ibm-im-test::install_was_response]
-
 ```
 
  We are currently working on smoothing out this process.
 
-```
+```shell
 bundle exec kitchen test
 ```
+
 or
-```
+
+```shell
 rake integration:vagrant
 ```

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,7 +1,7 @@
 #
 # Cookbook Name:: ibm-installmgr
 #
-# Copyright (C) 2015 J Sainsburys
+# Copyright (C) 2015-2018 J Sainsburys
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/ibm_fixpack.rb
+++ b/libraries/ibm_fixpack.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: ibm-installmgr
 # Resource:: ibm_package
 #
-# Copyright (C) 2015 J Sainsburys
+# Copyright (C) 2015-2018 J Sainsburys
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ module InstallMgrCookbook
 
         options << " -repositories '#{repositories_str}' " if new_resource.repositories
         options << ' -connectPassportAdvantage' if new_resource.passport_advantage
-        options << " -masterPasswordFile #{master_pw_file} -secureStorageFile #{secure_storage_file}" if new_resource.master_pw_file
+        options << " -masterPasswordFile #{master_pw_file} -secureStorageFile #{new_resource.secure_storage_file}" if new_resource.master_pw_file
         options << " -properties #{properties_str}" if new_resource.properties
         options << " -preferences #{preferences_str}" if new_resource.preferences
 

--- a/libraries/ibm_fixpack.rb
+++ b/libraries/ibm_fixpack.rb
@@ -27,58 +27,58 @@ module InstallMgrCookbook
     resource_name :ibm_fixpack
 
     action :install do
-      unless package_installed?(package, imcl_dir, true)
+      unless package_installed?(new_resource.package, new_resource.imcl_dir, true)
 
-        user service_user do
+        user new_resource.service_user do
           comment 'ibm installation mgr service account'
-          home "/home/#{service_user}"
+          home "/home/#{new_resource.service_user}"
           shell '/bin/bash'
-          not_if { service_user == 'root' }
+          not_if { new_resource.service_user == 'root' }
         end
 
-        directory "/home/#{service_user}" do
-          owner service_user
-          group service_user
+        directory "/home/#{new_resource.service_user}" do
+          owner new_resource.service_user
+          group new_resource.service_user
           mode '0750'
           recursive true
           action :create
-          not_if { service_user == 'root' }
+          not_if { new_resource.service_user == 'root' }
         end
 
-        group service_group do
-          members service_user
+        group new_resource.service_group do
+          members new_resource.service_user
           append true
-          not_if { service_group == 'root' }
+          not_if { new_resource.service_group == 'root' }
         end
 
-        directory log_dir do
-          owner service_user
-          group service_group
+        directory new_resource.log_dir do
+          owner new_resource.service_user
+          group new_resource.service_group
           mode '0755'
           recursive true
           action :create
         end
 
         date = Time.now.strftime('%d%b%Y-%H%M')
-        main_pkg = package.split(',').first
+        main_pkg = new_resource.package.split(',').first
         main_pkg = main_pkg.split('_').first
         logfile = "#{main_pkg}-install-#{date}.log"
 
         # packages_str = packages.join(' ') if packages
-        repositories_str = repositories.join(', ') if repositories
-        properties_str = properties.map { |k, v| "#{k}=#{v}" }.join(',') if properties
-        preferences_str = preferences.map { |k, v| "#{k}=#{v}" }.join(',') if preferences
+        repositories_str = new_resource.repositories.join(', ') if new_resource.repositories
+        properties_str = new_resource.properties.map { |k, v| "#{k}=#{v}" }.join(',') if new_resource.properties
+        preferences_str = new_resource.preferences.map { |k, v| "#{k}=#{v}" }.join(',') if new_resource.preferences
 
-        options = "-installationDirectory '#{install_dir}' -accessRights '#{access_rights}' "\
-        "-log #{log_dir}/#{logfile} -acceptLicense #{additional_options}"
+        options = "-installationDirectory '#{new_resource.install_dir}' -accessRights '#{new_resource.access_rights}' "\
+        "-log #{new_resource.log_dir}/#{logfile} -acceptLicense #{new_resource.additional_options}"
 
-        options << " -repositories '#{repositories_str}' " if repositories
-        options << ' -connectPassportAdvantage' if passport_advantage
-        options << " -masterPasswordFile #{master_pw_file} -secureStorageFile #{secure_storage_file}" if master_pw_file
-        options << " -properties #{properties_str}" if properties
-        options << " -preferences #{preferences_str}" if preferences
+        options << " -repositories '#{repositories_str}' " if new_resource.repositories
+        options << ' -connectPassportAdvantage' if new_resource.passport_advantage
+        options << " -masterPasswordFile #{master_pw_file} -secureStorageFile #{secure_storage_file}" if new_resource.master_pw_file
+        options << " -properties #{properties_str}" if new_resource.properties
+        options << " -preferences #{preferences_str}" if new_resource.preferences
 
-        imcl_wrapper(imcl_dir, "./imcl install '#{package}' -showProgress", options)
+        imcl_wrapper(new_resource.imcl_dir, "./imcl install '#{new_resource.package}' -showProgress", options)
       end
     end
 
@@ -88,10 +88,10 @@ module InstallMgrCookbook
       def imcl_wrapper(_imcl_directory, cmd, options)
         command = "#{cmd} #{options}"
 
-        execute "imcl install #{package}" do
-          cwd imcl_dir
+        execute "imcl install #{new_resource.package}" do
+          cwd new_resource.imcl_dir
           command command
-          sensitive sensitive_exec
+          sensitive new_resource.sensitive_exec
           action :run
         end
       end

--- a/libraries/ibm_package.rb
+++ b/libraries/ibm_package.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: ibm-installmgr
 # Resource:: ibm_package
 #
-# Copyright (C) 2018 J Sainsburys
+# Copyright (C) 2015-2018 J Sainsburys
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,11 +40,6 @@ module InstallMgrCookbook
     property :secure_storage_file, [String, nil], default: nil
     property :master_pw_file, [String, nil], default: nil
     property :sensitive_exec, [TrueClass, FalseClass], default: true # only turn this off in exceptional debugging circumstances.
-
-    # TODO: Include the below properties at some stage
-    # property :install_fixes, String, default: 'none', :regex => /^(none|recommended|all)$/
-    # property :preferences, [Hash], default: nil
-    # property :properties, [Hash], default: nil
 
     provides :ibm_package if defined?(provides)
 
@@ -87,8 +82,8 @@ module InstallMgrCookbook
 
         # packages_str = packages.join(' ') if packages
         repositories_str = new_resource.repositories.join(', ') if new_resource.repositories
-        properties_str = properties.map { |k, v| "#{k}=#{v}" }.join(',') if new_resource.properties
-        preferences_str = preferences.map { |k, v| "#{k}=#{v}" }.join(',') if new_resource.preferences
+        properties_str = new_resource.properties.map { |k, v| "#{k}=#{v}" }.join(',') if new_resource.properties
+        preferences_str = new_resource.preferences.map { |k, v| "#{k}=#{v}" }.join(',') if new_resource.preferences
 
         options = "-installationDirectory '#{new_resource.install_dir}' "\
         "-accessRights '#{new_resource.access_rights}' -log #{new_resource.log_dir}/#{logfile} "\
@@ -97,7 +92,7 @@ module InstallMgrCookbook
         options << " -repositories '#{repositories_str}' " if new_resource.repositories
         options << " -installFixes #{new_resource.install_fixes}"
         options << ' -connectPassportAdvantage' if new_resource.passport_advantage
-        options << " -masterPasswordFile #{new_resource.master_pw_file} -secureStorageFile #{secure_storage_file}" if new_resource.master_pw_file
+        options << " -masterPasswordFile #{new_resource.master_pw_file} -secureStorageFile #{new_resource.secure_storage_file}" if new_resource.master_pw_file
         options << " -properties #{properties_str}" if new_resource.properties
         options << " -preferences #{preferences_str}" if new_resource.preferences
 

--- a/libraries/ibm_package.rb
+++ b/libraries/ibm_package.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: ibm-installmgr
 # Resource:: ibm_package
 #
-# Copyright (C) 2015 J Sainsburys
+# Copyright (C) 2018 J Sainsburys
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,58 +49,59 @@ module InstallMgrCookbook
     provides :ibm_package if defined?(provides)
 
     action :install do
-      unless package_installed?(package, imcl_dir)
-        user service_user do
+      unless package_installed?(new_resource.package, new_resource.imcl_dir)
+        user new_resource.service_user do
           comment 'ibm installation mgr service account'
-          home "/home/#{service_user}"
+          home "/home/#{new_resource.service_user}"
           shell '/bin/bash'
-          not_if { service_user == 'root' }
+          not_if { new_resource.service_user == 'root' }
         end
 
-        directory "/home/#{service_user}" do
-          owner service_user
-          group service_user
+        directory "/home/#{new_resource.service_user}" do
+          owner new_resource.service_user
+          group new_resource.service_user
           mode '0750'
           recursive true
           action :create
-          not_if { service_user == 'root' }
+          not_if { new_resource.service_user == 'root' }
         end
 
-        group service_group do
-          members service_user
+        group new_resource.service_group do
+          members new_resource.service_user
           append true
-          not_if { service_group == 'root' }
+          not_if { new_resource.service_group == 'root' }
         end
 
-        directory log_dir do
-          owner service_user
-          group service_group
+        directory new_resource.log_dir do
+          owner new_resource.service_user
+          group new_resource.service_group
           mode '0755'
           recursive true
           action :create
         end
 
         date = Time.now.strftime('%d%b%Y-%H%M')
-        main_pkg = package.split(',').first
+        main_pkg = new_resource.package.split(',').first
         main_pkg = main_pkg.split('_').first
         logfile = "#{main_pkg}-install-#{date}.log"
 
         # packages_str = packages.join(' ') if packages
-        repositories_str = repositories.join(', ') if repositories
-        properties_str = properties.map { |k, v| "#{k}=#{v}" }.join(',') if properties
-        preferences_str = preferences.map { |k, v| "#{k}=#{v}" }.join(',') if preferences
+        repositories_str = new_resource.repositories.join(', ') if new_resource.repositories
+        properties_str = properties.map { |k, v| "#{k}=#{v}" }.join(',') if new_resource.properties
+        preferences_str = preferences.map { |k, v| "#{k}=#{v}" }.join(',') if new_resource.preferences
 
-        options = "-installationDirectory '#{install_dir}' -accessRights '#{access_rights}' "\
-        "-log #{log_dir}/#{logfile} -acceptLicense #{additional_options}"
+        options = "-installationDirectory '#{new_resource.install_dir}' "\
+        "-accessRights '#{new_resource.access_rights}' -log #{new_resource.log_dir}/#{logfile} "\
+        "-acceptLicense #{new_resource.additional_options}"
 
-        options << " -repositories '#{repositories_str}' " if repositories
-        options << " -installFixes #{install_fixes}"
-        options << ' -connectPassportAdvantage' if passport_advantage
-        options << " -masterPasswordFile #{master_pw_file} -secureStorageFile #{secure_storage_file}" if master_pw_file
-        options << " -properties #{properties_str}" if properties
-        options << " -preferences #{preferences_str}" if preferences
+        options << " -repositories '#{repositories_str}' " if new_resource.repositories
+        options << " -installFixes #{new_resource.install_fixes}"
+        options << ' -connectPassportAdvantage' if new_resource.passport_advantage
+        options << " -masterPasswordFile #{new_resource.master_pw_file} -secureStorageFile #{secure_storage_file}" if new_resource.master_pw_file
+        options << " -properties #{properties_str}" if new_resource.properties
+        options << " -preferences #{preferences_str}" if new_resource.preferences
 
-        imcl_wrapper(imcl_dir, "./imcl install '#{package}' -showProgress", options)
+        imcl_wrapper(new_resource.imcl_dir, "./imcl install '#{new_resource.package}' -showProgress", options)
       end
     end
 
@@ -110,10 +111,10 @@ module InstallMgrCookbook
       def imcl_wrapper(_imcl_directory, cmd, options)
         command = "#{cmd} #{options}"
 
-        execute "imcl install #{package}" do
-          cwd imcl_dir
+        execute "imcl install #{new_resource.package}" do
+          cwd new_resource.imcl_dir
           command command
-          sensitive sensitive_exec
+          sensitive new_resource.sensitive_exec
           action :run
         end
       end

--- a/libraries/ibm_package_response.rb
+++ b/libraries/ibm_package_response.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: ibm-installmgr
 # Resource:: ibm_package_response
 #
-# Copyright (C) 2015 J Sainsburys
+# Copyright (C) 2015-2018 J Sainsburys
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,19 +35,23 @@ module InstallMgrCookbook
     provides :ibm_package_response if defined?(provides)
 
     action :install do
-      unless package_installed?(package, imcl_dir)
-        directory log_dir do
-          owner pkg_owner
-          group pkg_group
+      unless package_installed?(new_resource.package, new_resource.imcl_dir)
+        directory new_resource.log_dir do
+          owner new_resource.pkg_owner
+          group new_resource.pkg_group
           mode '0755'
           recursive true
           action :create
         end
 
         date = Time.now.strftime('%d%b%Y-%H%M')
-        filename = ::File.basename(response_file, '.xml')
+        filename = ::File.basename(new_resource.response_file, '.xml')
         logfile = "#{filename}-#{date}.log"
-        imcl_wrapper(imcl_dir, "./imcl -accessRights \"#{access_rights}\" input \"#{response_file}\"", "-log \"#{log_dir}/#{logfile}\" -acceptLicense")
+        imcl_wrapper(
+          new_resource.imcl_dir,
+          "./imcl -accessRights \"#{new_resource.access_rights}\" input \"#{new_resource.response_file}\"",
+          "-log \"#{new_resource.log_dir}/#{logfile}\" -acceptLicense"
+        )
       end
     end
 
@@ -57,8 +61,8 @@ module InstallMgrCookbook
       def imcl_wrapper(_imcl_directory, cmd, options)
         command = "#{cmd} #{options}"
 
-        execute "imcl input #{response_file}" do
-          cwd imcl_dir
+        execute "imcl input #{new_resource.response_file}" do
+          cwd _imcl_directory
           command command
           action :run
         end

--- a/libraries/ibm_package_response.rb
+++ b/libraries/ibm_package_response.rb
@@ -62,7 +62,7 @@ module InstallMgrCookbook
         command = "#{cmd} #{options}"
 
         execute "imcl input #{new_resource.response_file}" do
-          cwd _imcl_directory
+          cwd new_resource.imcl_dir
           command command
           action :run
         end

--- a/libraries/ibm_response_file.rb
+++ b/libraries/ibm_response_file.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: ibm-installmgr
 # Resource:: ibm_response_file
 #
-# Copyright (C) 2015 J Sainsburys
+# Copyright (C) 2015-2018 J Sainsburys
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,24 +30,24 @@ module InstallMgrCookbook
     property :variables, [Hash, nil], default: nil
 
     action :create do
-      config_dir = ::File.dirname(response_file)
+      config_dir = ::File.dirname(new_resource.response_file)
 
       directory config_dir do
-        owner owner
-        group group
+        owner new_resource.owner
+        group new_resource.group
         mode '0750'
         recursive true
         action :create
       end
 
-      template "response_file :create #{response_file}" do
-        path response_file
-        owner owner
-        group group
+      template "response_file :create #{new_resource.response_file}" do
+        path new_resource.response_file
+        owner new_resource.owner
+        group new_resource.group
         mode '0750'
-        source template_source
-        cookbook cookbook
-        variables variables
+        source new_resource.template_source
+        cookbook new_resource.cookbook
+        variables new_resource.variables
         action :create
       end
     end

--- a/libraries/ibm_secure_storage_file.rb
+++ b/libraries/ibm_secure_storage_file.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: ibm-installmgr
 # Resource:: ibm_secure_storage_file
 #
-# Copyright (C) 2015 J Sainsburys
+# Copyright (C) 2015-2018 J Sainsburys
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,27 +32,27 @@ module InstallMgrCookbook
     property :sensitive_exec, [TrueClass, FalseClass], default: true
 
     action :create do
-      file master_pw_file do
-        content master_pw
+      file new_resource.master_pw_file do
+        content new_resource.master_pw
         mode '0600'
         sensitive true
       end
 
       # if passportAdvantage ignore url.
-      if passport_advantage
-        cmd = "./imutilsc saveCredential  -passportAdvantage -userName \"#{username}\" -userPassword "\
-        "\"#{password}\" -secureStorageFile \"#{secure_file}\" -masterPasswordFile \"#{master_pw_file}\""
-      else
-        cmd = "./imutilsc saveCredential  -url \"#{url}\" -userName \"#{username}\" -userPassword "\
-        "\"#{password}\" -secureStorageFile \"#{secure_file}\" -masterPasswordFile \"#{master_pw_file}\""
-      end
+      cmd = if new_resource.passport_advantage
+              "./imutilsc saveCredential  -passportAdvantage -userName \"#{new_resource.username}\" -userPassword "\
+              "\"#{new_resource.password}\" -secureStorageFile \"#{new_resource.secure_file}\" -masterPasswordFile \"#{new_resource.master_pw_file}\""
+            else
+              "./imutilsc saveCredential  -url \"#{new_resource.url}\" -userName \"#{new_resource.username}\" -userPassword "\
+              "\"#{new_resource.password}\" -secureStorageFile \"#{new_resource.secure_file}\" -masterPasswordFile \"#{new_resource.master_pw_file}\""
+            end
 
-      execute "imutilsc command #{secure_file}" do
-        cwd imutilsc_dir
+      execute "imutilsc command #{new_resource.secure_file}" do
+        cwd new_resource.imutilsc_dir
         command cmd
-        sensitive sensitive_exec
+        sensitive new_resource.sensitive_exec
         action :run
-        not_if { ::File.exist?(secure_file) }
+        not_if { ::File.exist?(new_resource.secure_file) }
       end
     end
   end

--- a/libraries/install_mgr.rb
+++ b/libraries/install_mgr.rb
@@ -89,7 +89,7 @@ module InstallMgrCookbook
               owner new_resource.service_user
               group new_resource.service_group
               mode '0750'
-              checksum install_package_sha256
+              checksum new_resource.install_package_sha256
               action :create
             end
           end
@@ -140,7 +140,7 @@ module InstallMgrCookbook
       def local_installer_file
         if url?(new_resource.install_package)
           filename = ::File.basename(new_resource.install_package)
-          local_file = "#{download_temp_dir}/#{filename}"
+          local_file = "#{new_resource.download_temp_dir}/#{filename}"
         else
           local_file = new_resource.install_package
         end

--- a/libraries/install_mgr.rb
+++ b/libraries/install_mgr.rb
@@ -76,6 +76,7 @@ module InstallMgrCookbook
             mode '0750'
             recursive true
             action :create
+            not_if { ::Dir.exist?(dir) }
           end
         end
 

--- a/libraries/install_mgr.rb
+++ b/libraries/install_mgr.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: ibm-installmgr
 # Resource:: install_mgr
 #
-# Copyright (C) 2015 J Sainsburys
+# Copyright (C) 2018 J Sainsburys
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,50 +42,51 @@ module InstallMgrCookbook
     provides :install_mgr if defined?(provides)
 
     action :install do
-      unless package_installed?(package_name, "#{install_dir}/tools")
+      unless package_installed?(new_resource.package_name, "#{new_resource.install_dir}/tools")
 
-        user service_user do
+        user new_resource.service_user do
           comment 'ibm installation mgr service account'
-          home "/home/#{service_user}"
+          home "/home/#{new_resource.service_user}"
           shell '/bin/bash'
-          not_if { service_user == 'root' }
+          not_if { new_resource.service_user == 'root' }
         end
 
-        directory "/home/#{service_user}" do
-          owner service_user
-          group service_user
+        directory "/home/#{new_resource.service_user}" do
+          owner new_resource.service_user
+          group new_resource.service_user
           mode '0750'
           recursive true
           action :create
-          not_if { service_user == 'root' }
+          not_if { new_resource.service_user == 'root' }
         end
 
-        group service_group do
-          members service_user
+        group new_resource.service_group do
+          members new_resource.service_user
           append true
-          not_if { service_group == 'root' }
+          not_if { new_resource.service_group == 'root' }
         end
 
         # create required dirs
-        dirs = %w(ibm_root_dir extract_dir install_dir data_location)
+        dirs = ["#{new_resource.ibm_root_dir}", "#{new_resource.extract_dir}",\
+                "#{new_resource.install_dir}", "#{new_resource.data_location}"]
         dirs.each do |dir|
           directory dir do
-            owner service_user
-            group service_group
+            owner new_resource.service_user
+            group new_resource.service_group
             mode '0750'
             recursive true
             action :create
           end
         end
 
-        if install_package
-          if url?(install_package)
+        if new_resource.install_package
+          if url?(new_resource.install_package)
             local_file = local_installer_file
 
             remote_file local_file do
-              source install_package
-              owner service_user
-              group service_group
+              source new_resource.install_package
+              owner new_resource.service_user
+              group new_resource.service_group
               mode '0750'
               checksum install_package_sha256
               action :create
@@ -97,26 +98,28 @@ module InstallMgrCookbook
 
           case ext
           when '.gz'
-            extract_tar(local_file, extract_dir)
+            extract_tar(local_file, new_resource.extract_dir)
           when '.tar'
-            extract_tar(local_file, extract_dir)
+            extract_tar(local_file, new_resource.extract_dir)
           when '.zip'
-            extract_zip(local_file, extract_dir)
+            extract_zip(local_file, new_resource.extract_dir)
           else
             Chef::Log.error('Unable to extract ibm Installation Manager Install package. It must be either tar, tar.gz or zip')
           end
 
         end
 
-        repositories_str = repositories.join(', ') if repositories
+        repositories_str = new_resource.repositories.join(', ') if new_resource.repositories
 
-        cmd = "./imcl install \"#{package_name}\" "\
-        "-installationDirectory \"#{install_dir}\" -accessRights \"#{access_rights}\" "\
-        "-acceptLicense -dataLocation \"#{data_location}\" -preferences #{preferences}"
-        cmd << " -repositories '#{repositories_str}' " if repositories
+        cmd = "./imcl install \"#{new_resource.package_name}\" "\
+        "-installationDirectory \"#{new_resource.install_dir}\" "\
+        "-accessRights \"#{new_resource.access_rights}\" "\
+        "-acceptLicense -dataLocation \"#{new_resource.data_location}\" "\
+        " -preferences #{new_resource.preferences}"
+        cmd << " -repositories '#{repositories_str}' " if new_resource.repositories
 
-        execute "install im #{package_name}" do
-          cwd "#{extract_dir}/tools"
+        execute "install im #{new_resource.package_name}" do
+          cwd "#{new_resource.extract_dir}/tools"
           command cmd
           action :run
         end
@@ -134,11 +137,11 @@ module InstallMgrCookbook
 
       # helper function to return valid path to installer zip/tar
       def local_installer_file
-        if url?(install_package)
-          filename = ::File.basename(install_package)
+        if url?(new_resource.install_package)
+          filename = ::File.basename(new_resource.install_package)
           local_file = "#{download_temp_dir}/#{filename}"
         else
-          local_file = install_package
+          local_file = new_resource.install_package
         end
         local_file
       end

--- a/libraries/install_mgr.rb
+++ b/libraries/install_mgr.rb
@@ -132,7 +132,7 @@ module InstallMgrCookbook
     # so they are available in the action.
     action_class.class_eval do
       def url?(string)
-        checks = %w(http https)
+        checks = %w(http https file)
         checks.any? { |str| string.include? str }
       end
 

--- a/libraries/install_mgr.rb
+++ b/libraries/install_mgr.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: ibm-installmgr
 # Resource:: install_mgr
 #
-# Copyright (C) 2018 J Sainsburys
+# Copyright (C) 2015-2018 J Sainsburys
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,8 +67,8 @@ module InstallMgrCookbook
         end
 
         # create required dirs
-        dirs = ["#{new_resource.ibm_root_dir}", "#{new_resource.extract_dir}",\
-                "#{new_resource.install_dir}", "#{new_resource.data_location}"]
+        dirs = [new_resource.ibm_root_dir.to_s, new_resource.extract_dir.to_s,\
+                new_resource.install_dir.to_s, new_resource.data_location.to_s]
         dirs.each do |dir|
           directory dir do
             owner new_resource.service_user

--- a/libraries/install_mgr.rb
+++ b/libraries/install_mgr.rb
@@ -132,7 +132,7 @@ module InstallMgrCookbook
     # so they are available in the action.
     action_class.class_eval do
       def url?(string)
-        checks = %w(http https file)
+        checks = %w[http https file]
         checks.any? { |str| string.include? str }
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,13 @@
 name 'ibm-installmgr'
 maintainer 'Sainsburys Devops'
 maintainer_email 'devops@sainsburys.co.uk'
-license 'Apache 2.0'
+license 'Apache-2.0'
 description 'Installs/Configures IBM Installation Manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.3.0'
+supports 'redhat'
+supports 'centos'
+
+issues_url 'https://github.com/Sainsburys/ibm-installmgr/issues'
+source_url 'https://github.com/Sainsburys/ibm-installmgr'
+chef_version '>= 12.5' if respond_to?(:chef_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'devops@sainsburys.co.uk'
 license 'Apache 2.0'
 description 'Installs/Configures IBM Installation Manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.0'
+version '1.3.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,17 @@ def stub_commands
   stub_command('which sudo').and_return('/usr/bin/sudo')
 end
 
-at_exit { ChefSpec::Coverage.report! }
+RSpec.configure do |config|
+  config.platform = 'centos'
+  config.version = '6.8'
+  config.log_level = :error
+  # Prohibit using the should syntax
+  config.expect_with :rspec do |spec|
+    spec.syntax = :expect
+  end
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = 'random'
+end

--- a/spec/unit/install_im_spec.rb
+++ b/spec/unit/install_im_spec.rb
@@ -34,7 +34,7 @@ describe 'ibm-im-test::install_im' do
       expect(centos_67_install_im).to create_group('ibm-im')
     end
 
-    dirs = %w(ibm_root_dir extract_dir install_dir data_location)
+    dirs = %w[ibm_root_dir extract_dir install_dir data_location]
     it 'creates these directories' do
       dirs.each do |dir|
         expect(centos_67_install_im).to create_directory(dir).with(

--- a/spec/unit/install_im_spec.rb
+++ b/spec/unit/install_im_spec.rb
@@ -3,9 +3,8 @@ require 'spec_helper'
 describe 'ibm-im-test::install_im' do
   cached(:centos_67_install_im) do
     ChefSpec::ServerRunner.new(
-      step_into: 'install_mgr',
-      platform: 'centos',
-      version: '6.6'
+      file_cache_path: '/tmp/cache',
+      step_into: 'install_mgr'
     ) do
     end.converge('ibm-im-test::install_im')
   end
@@ -34,7 +33,12 @@ describe 'ibm-im-test::install_im' do
       expect(centos_67_install_im).to create_group('ibm-im')
     end
 
-    dirs = %w[ibm_root_dir extract_dir install_dir data_location]
+    dirs = %w[
+      /opt/IBM
+      /tmp/cache/ibm-installmgr
+      /opt/IBM/InstallationManager/eclipse
+      /var/IBM/InstallationManager
+    ]
     it 'creates these directories' do
       dirs.each do |dir|
         expect(centos_67_install_im).to create_directory(dir).with(

--- a/spec/unit/install_passport_spec.rb
+++ b/spec/unit/install_passport_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'ibm-im-test::install_passport' do
   cached(:centos_67_install_passport) do
     ChefSpec::ServerRunner.new(
-      step_into: %w(ibm_secure_storage_file ibm_package),
+      step_into: %w[ibm_secure_storage_file ibm_package],
       platform: 'centos',
       version: '6.6'
     ) do |node|

--- a/spec/unit/install_passport_spec.rb
+++ b/spec/unit/install_passport_spec.rb
@@ -3,12 +3,10 @@ require 'spec_helper'
 describe 'ibm-im-test::install_passport' do
   cached(:centos_67_install_passport) do
     ChefSpec::ServerRunner.new(
-      step_into: %w[ibm_secure_storage_file ibm_package],
-      platform: 'centos',
-      version: '6.6'
+      step_into: %w[ibm_secure_storage_file ibm_package]
     ) do |node|
-      node.set['ibm-im-test']['passport_advantage']['user'] = 'dummyuser'
-      node.set['ibm-im-test']['passport_advantage']['password'] = 'dummypw'
+      node.default['ibm-im-test']['passport_advantage']['user'] = 'dummyuser'
+      node.default['ibm-im-test']['passport_advantage']['password'] = 'dummypw'
     end.converge('ibm-im-test::install_passport')
   end
 

--- a/spec/unit/install_was_response_spec.rb
+++ b/spec/unit/install_was_response_spec.rb
@@ -3,9 +3,7 @@ require 'spec_helper'
 describe 'ibm-im-test::install_was_response' do
   cached(:centos_67_install_was) do
     ChefSpec::ServerRunner.new(
-      step_into: 'ibm_package_response',
-      platform: 'centos',
-      version: '6.6'
+      step_into: 'ibm_package_response'
     ) do
     end.converge('ibm-im-test::install_was_response')
   end


### PR DESCRIPTION
[Description]
- The directories were being created as the actual variable names instead of being created with the value of the variable.
- Fixed Chef-13 deprecation issues. For more details see docs.chef.io/deprecations_namespace_collisions.html
- Fixed certain Markdown and Rubocop warnings.